### PR TITLE
Update of time-analysis.py to allow a split range for counting

### DIFF
--- a/plot-spectra.py
+++ b/plot-spectra.py
@@ -109,11 +109,22 @@ if (variable is not None):
 
 with uproot.open(path_all) as f2:
     
-    h1=utils.get_hist(f2[f"{spectrum}/{dataset}"],(energy_low,energy_high),binning,edges)
+    if ("mul2" in spectrum):
+
+        h1=utils.get_hist(f2[f"mul2_surv_2d/all{spectrum}/{dataset}"],(energy_low,energy_high),binning,edges,spectrum)
+    else:
+        h1=utils.get_hist(f2[f"{spectrum}/{dataset}"],(energy_low,energy_high),binning,edges,spectrum)
+
 
 with uproot.open(path) as f2:
     
-    h2=utils.get_hist(f2[f"{spectrum}/{dataset}"],(energy_low,energy_high),binning,edges)
+    if ("mul2" in spectrum):
+
+        h2=utils.get_hist(f2[f"mul2_surv_2d/all{spectrum}/{dataset}"],(energy_low,energy_high),binning,edges,spectrum)
+    else:
+        h2=utils.get_hist(f2[f"{spectrum}/{dataset}"],(energy_low,energy_high),binning,edges,spectrum)
+
+
 
 for i in range(h1.size-2):
     h1[i]/=exp_nu

--- a/plot-spectra.py
+++ b/plot-spectra.py
@@ -24,7 +24,15 @@ import sys
 import re
 import json
 from legendmeta import LegendMetadata
-plt.rcParams.update({'font.size': 24}) 
+plt.rcParams.update({
+    'font.size': 20,          # Main font size
+    'axes.labelsize': 20,     # Font size of x and y labels
+    'axes.titlesize': 20,     # Font size of titles
+    'xtick.labelsize': 16,    # Font size of x-axis ticks
+    'ytick.labelsize': 16,    # Font size of y-axis ticks
+    'legend.fontsize': 14,    # Font size of legend
+    'figure.titlesize': 20    # Font size of figure titles
+})
 
 from matplotlib.backends.backend_pdf import PdfPages
 vset = tc.tol_cset('vibrant')
@@ -111,7 +119,7 @@ with uproot.open(path_all) as f2:
     
     if ("mul2" in spectrum):
 
-        h1=utils.get_hist(f2[f"mul2_surv_2d/all{spectrum}/{dataset}"],(energy_low,energy_high),binning,edges,spectrum)
+        h1=utils.get_hist(f2[f"mul2_surv_2d/all"],(energy_low,energy_high),binning,edges,spectrum)
     else:
         h1=utils.get_hist(f2[f"{spectrum}/{dataset}"],(energy_low,energy_high),binning,edges,spectrum)
 
@@ -120,7 +128,7 @@ with uproot.open(path) as f2:
     
     if ("mul2" in spectrum):
 
-        h2=utils.get_hist(f2[f"mul2_surv_2d/all{spectrum}/{dataset}"],(energy_low,energy_high),binning,edges,spectrum)
+        h2=utils.get_hist(f2[f"mul2_surv_2d/all"],(energy_low,energy_high),binning,edges,spectrum)
     else:
         h2=utils.get_hist(f2[f"{spectrum}/{dataset}"],(energy_low,energy_high),binning,edges,spectrum)
 

--- a/utils.py
+++ b/utils.py
@@ -170,7 +170,12 @@ def get_error_bar(N:float):
 
     x= np.linspace(0,5+2*N,5000)
     y=poisson.pmf(N,x)
-    return get_smallest_ci(N,x,y)
+    histo = ( Hist.new.Reg(5000, 0, 0.5+2*N).Double())
+ 
+    for i in range(histo.size-2):
+        histo[i]=y[i]
+
+    return get_smallest_ci(N,x,y)[0],get_smallest_ci(N,x,y)[1],histo
 
 
 def get_hist(obj,range:tuple=(132,4195),bins:int=10,variable=None,spectrum="mul_surv"):
@@ -209,7 +214,16 @@ def normalise_histo(hist,factor=1):
         hist[i]*=factor
     return hist
 
-def integrate_hist(hist,low,high):
+def integrate_hist(hist,energies):
+
+    integral = 0
+    for e in energies:
+        integral +=integrate_hist_one_range(hist,e[0],e[1])
+    
+    
+    return integral
+
+def integrate_hist_one_range(hist,low,high):
     """ Integrate the histogram"""
 
     bin_centers= hist.axes.centers[0]
@@ -345,9 +359,7 @@ def sample_hist(hist,N):
 
     edges = hist.axes[0].edges
     int = sum(hist.values())
-
     counts = hist.view()
-
     bin_widths = np.diff(edges)
     probabilities = counts / np.sum(counts )
 

--- a/utils.py
+++ b/utils.py
@@ -173,7 +173,7 @@ def get_error_bar(N:float):
     return get_smallest_ci(N,x,y)
 
 
-def get_hist(obj,range:tuple=(132,4195),bins:int=10,variable=None):
+def get_hist(obj,range:tuple=(132,4195),bins:int=10,variable=None,spectrum="mul_surv"):
     """                                                                                                                                                                                                    
     Extract the histogram (hist package object) from the uproot histogram                                                                                                                                  
     Parameters:                                                                                                                                                                                            
@@ -184,8 +184,12 @@ def get_hist(obj,range:tuple=(132,4195),bins:int=10,variable=None):
         - hist                                                                                                                                                                                             
     """
    
-        
-    h=obj.to_hist()[range[0]:range[1]]
+    if (spectrum=="mul2_surv_e1"):
+        h=obj.to_hist().project(1)[range[0]:range[1]]
+    elif (spectrum=="mul2_surv_e2"):
+        h=obj.to_hist().project(0)[range[0]:range[1]]
+    else:
+        h=obj.to_hist()[range[0]:range[1]]
 
     if (variable is not None):
         h=normalise_histo(variable_rebin(h,variable))


### PR DESCRIPTION
The user can now supply a disjoint range for the energy integrals in `time-analysis.py` like
    
 `python time-analysis.py -e "(2000,2100),(2200,2300)"`
 
 in the case a single range is suppled, the code will work as before, others a list of tuples (in parentheses) should be supplied.