### PR TITLE
fix of the order of rawids ak subarrays

### DIFF
--- a/build_data.py
+++ b/build_data.py
@@ -266,6 +266,7 @@ def get_data_awkard(cfg:dict,periods=None,target_key=None,Nmax:int=None,run_list
                     # get uniques rawids for loading hit data
                     rawids = np.unique(ak.to_numpy(ak.ravel(tcm.id)))
                     energy = None
+                    rawid_sort=None
                     physical =None
 
                     # for each table in the hit file
@@ -283,16 +284,16 @@ def get_data_awkard(cfg:dict,periods=None,target_key=None,Nmax:int=None,run_list
                             idx=ak.to_numpy(ak.flatten(idx_mask)),
                         )
 
-                    
                         # now bring back to original shape
                         data_unf = ak.unflatten(energy_data, idx_loc)
-
+                        rawid_unf=ak.full_like(data_unf,rawid,dtype="int")
                         energy = (
                             data_unf if energy is None else ak.concatenate((energy, data_unf), axis=-1)
                         )
-                     
+                        rawid_sort= (rawid_unf if rawid_sort is None else ak.concatenate((rawid_sort,rawid_unf),axis=-1))
+
                     d_evt["geds", "unphysical_hit_rawid"] = tcm_unphysical.id
-                    d_evt["geds", "hit_rawid"] = tcm.id
+                    d_evt["geds", "hit_rawid"] = rawid_sort
                     d_evt["geds", "energy"] = energy
                  
                     if run in metadb.dataprod.runinfo[period].keys():
@@ -300,6 +301,7 @@ def get_data_awkard(cfg:dict,periods=None,target_key=None,Nmax:int=None,run_list
                     else:
                         start = json.load(open('/data1/users/calgaro/legend-metadata/dataprod/runinfo.json'))[period][run]["phy"]["start_key"]
                         ch = metadb.channelmap(start)
+                    
                     ac = [ _dict["daq"]["rawid"] for _name, _dict in ch.items() if ch[_name]["system"] == "geds" and ch[_name]["analysis"]["usability"] in ["ac"]]
                     off= [ _dict["daq"]["rawid"] for _name, _dict in ch.items() if ch[_name]["system"] == "geds" and ch[_name]["analysis"]["usability"] in ["off"]]
 
@@ -558,7 +560,7 @@ def main():
 
     # analysis runs
     runs=metadb.dataprod.config.analysis_runs
-    runs['p10']=['r000','r001','r002','r003']
+    runs['p10']=['r004']
 
     os.makedirs("outputs",exist_ok=True)
     output_cache = f"outputs/{out_name.replace('.root', '.parquet')}"
@@ -572,39 +574,25 @@ def main():
 
     print("Got data")
     print(recompute_qc_flag)
-
     ### Add cuts on bad channels
     ### ---------------------------------------------------------------------
     ### For ON->AC this is just another cut
     ### FOR ON/AC -> OFF we need to modify the geds.energy geds.hit_rawid and geds.is_good_hit,
     ### to remove this hits, we then need to modify mulitplicity
     qcs_flag = "is_good_hit" if args.qc=="old" else "is_good_hit_new"
-    import collections
-    ### first print the data
-    #data = data[ (~data.trigger.is_forced)    # no forced triggers
-              #      & (~data.coincident.puls) # no pulser eventsdata
-              #          & (~data.coincident.muon) ]
 
-    count = dict(collections.Counter(ak.flatten(data["geds","unphysical_hit_rawid"])))
-    sorted_map_by_keys = dict(sorted(count.items(),key=lambda item: item[1],reverse=True))
-    for c,i in sorted_map_by_keys.items():
-        print(geds_mapping[f"ch{c}"]," ",i)
-    print("\n")
     data=filter_off_ac(data,qcs_flag=qcs_flag,off_dets=usability["ac_to_off"],ac_dets=usability["ac"])
-    count = dict(collections.Counter(ak.flatten(data["geds","unphysical_hit_rawid"])))
-    sorted_map_by_keys = dict(sorted(count.items(),key=lambda item: item[1],reverse=True))
+    print_events(data,qcs_flag)
 
-    for c,i in sorted_map_by_keys.items():
-        print(geds_mapping[f"ch{c}"]," ",i)
-    print("\n")
 
     ### and the usual cuts
     data = data[ (~data.trigger.is_forced)    # no forced triggers
                     & (~data.coincident.puls) # no pulser eventsdata
                     & (~data.coincident.muon) # no muons
                     & (data.geds.multiplicity > 0) # no purely lar triggered events
-                   &(ak.all(data.geds[qcs_flag],axis=-1))
+                  # &(ak.all(data.geds[qcs_flag],axis=-1))
                     ]
+    
     
 
 

--- a/build_data.py
+++ b/build_data.py
@@ -582,7 +582,6 @@ def main():
     qcs_flag = "is_good_hit" if args.qc=="old" else "is_good_hit_new"
 
     data=filter_off_ac(data,qcs_flag=qcs_flag,off_dets=usability["ac_to_off"],ac_dets=usability["ac"])
-    print_events(data,qcs_flag)
 
 
     ### and the usual cuts
@@ -590,7 +589,7 @@ def main():
                     & (~data.coincident.puls) # no pulser eventsdata
                     & (~data.coincident.muon) # no muons
                     & (data.geds.multiplicity > 0) # no purely lar triggered events
-                  # &(ak.all(data.geds[qcs_flag],axis=-1))
+                   &(ak.all(data.geds[qcs_flag],axis=-1))
                     ]
     
     

--- a/utils.py
+++ b/utils.py
@@ -170,7 +170,12 @@ def get_error_bar(N:float):
 
     x= np.linspace(0,5+2*N,5000)
     y=poisson.pmf(N,x)
-    return get_smallest_ci(N,x,y)
+    histo = ( Hist.new.Reg(5000, 0, 0.5+2*N).Double())
+ 
+    for i in range(histo.size-2):
+        histo[i]=y[i]
+
+    return get_smallest_ci(N,x,y)[0],get_smallest_ci(N,x,y)[1],histo
 
 
 def get_hist(obj,range:tuple=(132,4195),bins:int=10,variable=None,spectrum="mul_surv"):
@@ -209,7 +214,16 @@ def normalise_histo(hist,factor=1):
         hist[i]*=factor
     return hist
 
-def integrate_hist(hist,low,high):
+def integrate_hist(hist,energies):
+
+    integral = 0
+    for e in energies:
+        integral +=integrate_hist_one_range(hist,e[0],e[1])
+    
+    
+    return integral
+
+def integrate_hist_one_range(hist,low,high):
     """ Integrate the histogram"""
 
     bin_centers= hist.axes.centers[0]
@@ -345,9 +359,7 @@ def sample_hist(hist,N):
 
     edges = hist.axes[0].edges
     int = sum(hist.values())
-
     counts = hist.view()
-
     bin_widths = np.diff(edges)
     probabilities = counts / np.sum(counts )
 


### PR DESCRIPTION
Previosuly the ak array ``data["geds"]["energy"]`` where ordered by rawid. Since the code looped over the rawids when filling the energy array.
This PR, builds the ``data["geds"]["hit_rawid"]`` array in the same way so the correspondence of rawid and energy is preserved.
